### PR TITLE
Fix +1 error in namingtable, and add support for more os/2 table versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "truetype"
-version = "0.23.1"
+version = "0.24.0"
 license = "Apache-2.0/MIT"
 authors = ["Ivan Ukhov <ivan.ukhov@gmail.com>"]
 description = "The package provides a parser for TrueType fonts."

--- a/src/naming_table.rs
+++ b/src/naming_table.rs
@@ -121,7 +121,7 @@ impl NamingTable1 {
 fn data_length(records: &[Record]) -> usize {
     let mut length = 0;
     for record in records {
-        let end = record.offset + record.length + 1;
+        let end = record.offset + record.length;
         if end > length {
             length = end;
         }

--- a/src/windows_metrics.rs
+++ b/src/windows_metrics.rs
@@ -4,18 +4,96 @@
 
 use {Result, Tape, Value};
 
-/// OS/2 and Windows metrics.
+/// OS/2 and Windows metrics.  The version identifies the layout
+/// of the table, with the same layout being shared by multiple
+/// versions in some cases.
 #[derive(Clone, Debug)]
 pub enum WindowsMetrics {
-    /// Version 3.0.
-    Version3(WindowsMetrics3),
-    /// Version 5.0.
+    Version0(WindowsMetrics0),
+    Version1(WindowsMetrics1),
+    Version2(WindowsMetrics2),
+    Version3(WindowsMetrics2),
+    Version4(WindowsMetrics2),
     Version5(WindowsMetrics5),
 }
 
 table! {
-    #[doc = "OS/2 and Windows metrics of version 3.0."]
-    pub WindowsMetrics3 {
+    #[doc = "OS/2 and Windows metrics of version 0."]
+    pub WindowsMetrics0 {
+        version               (u16           ), // version
+        average_char_width    (i16           ), // xAvgCharWidth
+        weight_class          (u16           ), // usWeightClass
+        width_class           (u16           ), // usWidthClass
+        type_flags            (TypeFlags     ), // fsType
+        subscript_x_size      (i16           ), // ySubscriptXSize
+        subscript_y_size      (i16           ), // ySubscriptYSize
+        subscript_x_offset    (i16           ), // ySubscriptXOffset
+        subscript_y_offset    (i16           ), // ySubscriptYOffset
+        superscript_x_size    (i16           ), // ySuperscriptXSize
+        superscript_y_size    (i16           ), // ySuperscriptYSize
+        superscript_x_offset  (i16           ), // ySuperscriptXOffset
+        superscript_y_offset  (i16           ), // ySuperscriptYOffset
+        strikeout_size        (i16           ), // yStrikeoutSize
+        strikeout_position    (i16           ), // yStrikeoutPosition
+        family_class          (i16           ), // sFamilyClass
+        panose                ([u8; 10]      ), // panose
+        unicode_range1        (u32           ), // ulUnicodeRange1
+        unicode_range2        (u32           ), // ulUnicodeRange2
+        unicode_range3        (u32           ), // ulUnicodeRange3
+        unicode_range4        (u32           ), // ulUnicodeRange4
+        vendor_id             ([i8; 4]       ), // achVendID
+        selection_flags       (SelectionFlags), // fsSelection
+        first_char_index      (u16           ), // usFirstCharIndex
+        last_char_index       (u16           ), // usLastCharIndex
+        typographic_ascender  (i16           ), // sTypoAscender
+        typographic_descender (i16           ), // sTypoDescender
+        typographic_line_gap  (i16           ), // sTypoLineGap
+        windows_ascender      (u16           ), // usWinAscent
+        windows_descender     (u16           ), // usWinDescent
+    }
+}
+
+table! {
+    #[doc = "OS/2 and Windows metrics of version 1."]
+    pub WindowsMetrics1 {
+        version               (u16           ), // version
+        average_char_width    (i16           ), // xAvgCharWidth
+        weight_class          (u16           ), // usWeightClass
+        width_class           (u16           ), // usWidthClass
+        type_flags            (TypeFlags     ), // fsType
+        subscript_x_size      (i16           ), // ySubscriptXSize
+        subscript_y_size      (i16           ), // ySubscriptYSize
+        subscript_x_offset    (i16           ), // ySubscriptXOffset
+        subscript_y_offset    (i16           ), // ySubscriptYOffset
+        superscript_x_size    (i16           ), // ySuperscriptXSize
+        superscript_y_size    (i16           ), // ySuperscriptYSize
+        superscript_x_offset  (i16           ), // ySuperscriptXOffset
+        superscript_y_offset  (i16           ), // ySuperscriptYOffset
+        strikeout_size        (i16           ), // yStrikeoutSize
+        strikeout_position    (i16           ), // yStrikeoutPosition
+        family_class          (i16           ), // sFamilyClass
+        panose                ([u8; 10]      ), // panose
+        unicode_range1        (u32           ), // ulUnicodeRange1
+        unicode_range2        (u32           ), // ulUnicodeRange2
+        unicode_range3        (u32           ), // ulUnicodeRange3
+        unicode_range4        (u32           ), // ulUnicodeRange4
+        vendor_id             ([i8; 4]       ), // achVendID
+        selection_flags       (SelectionFlags), // fsSelection
+        first_char_index      (u16           ), // usFirstCharIndex
+        last_char_index       (u16           ), // usLastCharIndex
+        typographic_ascender  (i16           ), // sTypoAscender
+        typographic_descender (i16           ), // sTypoDescender
+        typographic_line_gap  (i16           ), // sTypoLineGap
+        windows_ascender      (u16           ), // usWinAscent
+        windows_descender     (u16           ), // usWinDescent
+        code_page_range1      (u32           ), // ulCodePageRange1
+        code_page_range2      (u32           ), // ulCodePageRange2
+    }
+}
+
+table! {
+    #[doc = "OS/2 and Windows metrics of version 2/3/4."]
+    pub WindowsMetrics2 {
         version               (u16           ), // version
         average_char_width    (i16           ), // xAvgCharWidth
         weight_class          (u16           ), // usWeightClass
@@ -57,7 +135,7 @@ table! {
 }
 
 table! {
-    #[doc = "OS/2 and Windows metrics of version 5.0."]
+    #[doc = "OS/2 and Windows metrics of version 5."]
     pub WindowsMetrics5 {
         version                  (u16           ), // version
         average_char_width       (i16           ), // xAvgCharWidth
@@ -118,9 +196,13 @@ flags! {
 impl Value for WindowsMetrics {
     fn read<T: Tape>(tape: &mut T) -> Result<Self> {
         Ok(match try!(tape.peek::<u16>()) {
+            0 => WindowsMetrics::Version0(try!(tape.take())),
+            1 => WindowsMetrics::Version1(try!(tape.take())),
+            2 => WindowsMetrics::Version2(try!(tape.take())),
             3 => WindowsMetrics::Version3(try!(tape.take())),
+            4 => WindowsMetrics::Version4(try!(tape.take())),
             5 => WindowsMetrics::Version5(try!(tape.take())),
-            _ => raise!("found an unknown format of the OS/2 and Windows metrics"),
+            v => raise!(format!("found an unknown version ({}) of the OS/2 and Windows metrics", v)),
         })
     }
 }


### PR DESCRIPTION
(If you would prefer this as separate PRs let me know, this was simpler)

It would be nice if the OS/2 table support just had a single max-version struct, with the fields not actually present in the file being zero'd out.  The consumer should check the version field and only use appropriate fields, as they should already be looking at version anyway to properly interpret some of the fields.

Prehaps a `versioned_table!` macro, where each field has a minimum version number?

(Note that I'm planning on using this crate in Servo to provide support for extracting some basic info from web fonts on Windows, hence these fixes)